### PR TITLE
fix: Remove setAutoPadding setting for add padding automatically

### DIFF
--- a/decrypt.js
+++ b/decrypt.js
@@ -14,16 +14,16 @@ fetch('URL_PATH')
 			iv
 		);
 
-		decipher.setAutoPadding(false);
-
-		const json = decipher.update(
+		let json = decipher.update(
 			dat,
 			'base64',
 			'utf8'
 		);
 
+		json += decipher.final('utf8');
+
 		// user answer json
-		console.log(json);
+		console.log(JSON.stringify(JSON.parse(json)));
 
 	})
 	.catch((err) => console.log(err));


### PR DESCRIPTION
Default padding setting is true for AES spec.

It works on node v8.1.3

ref: https://nodejs.org/api/crypto.html#crypto_decipher_setautopadding_autopadding